### PR TITLE
[Fixes #4] Feature/literals

### DIFF
--- a/docs/extending.rst
+++ b/docs/extending.rst
@@ -108,3 +108,11 @@ matches any in the second argument.  The matching tag is saved as
 
 These can be rendered easily by calling their ``render`` method, which works
 just like a ``BlockNode``.
+
+Expressions
+-----------
+
+To have an argument resolved as an expression, construct an ``Expression``
+class, passing it the content.
+
+Then in render, call ``.resolve(context)`` to get its value.

--- a/docs/writing.rst
+++ b/docs/writing.rst
@@ -11,12 +11,52 @@ There are 3 basic types of tags:
 - block
 - comment
 
+
+Expressions
+===========
+
+At several points in the syntax, an Expression can be used.
+
+They start with a value, optionally followed by a series of filters.
+
+A value can be:
+
+- an integer
+- a float
+- a string
+- a lookup
+
+A lookup will try to delve into the Context.  For example the expression
+``name`` Will look for Context['name'].
+
+However, lookups can delve deeper.  They will attempt dict lookups, attribute
+lookup, and list indexing (in that order).  Also, if the resulting value is
+callable, it will be called.
+
+So, to get the ``name`` attribute of your ``user`` object, and call its
+``title`` method, the expression would be ``name:user:title``.
+
+Filters allow you to pass the value (and possibly more arguments) to helper
+functions.  For example, you might have a dollar format function:
+
+.. code-block:: python
+
+    def dollar_format(value, currency_symbol='$'):
+        return "%s%0.2f" % (currency_symbol, float(value))
+
+If this is registered as a filter, you can now in your templates use the
+expression ``product:price|dollar_format``, or even override the currency
+symbol using ``product:price|dollar_format:'¥'``
+
+Filters can be chained, one after another.
+
+There are currently no default filters provided with Stencil.
+
 Comments
 ========
 
 Comment tags are discarded during parsing, and are only for the benefit of
 future template editors.  They have no impact on rendering performance.
-
 
 Variables
 =========
@@ -25,41 +65,7 @@ Var tags are used to display the values of variables.  They look like this:
 
 .. code-block:: html
 
-   Hello {{ name }}
-
-In this case, the ``{{ name }}`` block will render as the value of the `name`
-value in the Context.
-
-You can delve into data strucures using a "dot notation", for instance:
-
-.. code-block:: html
-
-   {{ user.first_name.title }}
-
-If the ``user`` object has a string attribute of ``first_name``, this will
-render the output of calling its ``title`` method.
-
-Additionally, the values can be pushed through `filters`.  An example might be
-if you wrote a tool for format a number as a dollar string.
-
-.. code-block:: html
-
-   {{ product.price|dollar_format }}
-
-Which might render as:
-
-.. code-block:: html
-
-    $129.95
-
-Filters can also take extra arguments:
-
-.. code-block:: html
-
-   {{ product.price|float_format,%0.2f,$ }}
-
-There are currently no built in filters.  You can add them to your render
-Context at run time.
+   Hello {{ expr }}
 
 Block Tags
 ==========
@@ -68,7 +74,7 @@ Block tags perform some action, may render some output, and may "contain" other 
 
 .. code-block:: html
 
-   {% include another.html %}
+   {% include 'another.html' %}
 
 -------------
 Built In Tags
@@ -81,7 +87,7 @@ The ``for`` tag allows you to loop over a sequence.
 
 .. code-block:: html
 
-    {% for x in y %}
+    {% for x in expr %}
     ...
     {% endfor %}
 
@@ -103,7 +109,7 @@ The ``if`` tag allows for simple flow control based on a truthy test.
 
 .. code-block:: html
 
-   {% if something %}
+   {% if expr %}
    Success!
    {% endif %}
 
@@ -111,7 +117,7 @@ It also supports negative cases:
 
 .. code-block:: html
 
-   {% if not something %}
+   {% if not expr %}
    Failure!
    {% endif %}
 
@@ -119,7 +125,7 @@ And, like the ``for`` tag, it supports an ``else`` block:
 
 .. code-block:: html
 
-   {% if something %}
+   {% if expr %}
    Success!
    {% else %}
    Failure!
@@ -147,7 +153,7 @@ context.
 
 .. code-block:: html
 
-    {% include side_menu.html %}
+    {% include expr %}
 
 Additionally, you can pass extra expressions to be added to the
 context whilst the other template is being rendered.
@@ -164,7 +170,7 @@ template.  See _extending for more details.
 
 .. code-block:: html
 
-   {% load myproject.tags %}
+   {% load 'myproject.tags' %}
 
 The value passed is a Python import path.
 

--- a/stencil.py
+++ b/stencil.py
@@ -138,16 +138,16 @@ class Expression(object):
             return value, next(self.tokens)
         elif tok[0] == tokenize.NUMBER:
             try:
-                value = float(tok[1])
-            except ValueError:
                 value = int(tok[1])
+            except ValueError:
+                value = float(tok[1])
             return value, next(self.tokens)
         elif tok[0] == tokenize.NAME:
             var = [tok[1]]
             tok = next(self.tokens)
-            while tok[0] == tokenize.OP and tok[1] == '.':
+            while tok[0] == tokenize.OP and tok[1] == '>':
                 tok = next(self.tokens)
-                assert tok[0] == tokenize.NAME, "Invalid syntax in expression at %d: %r" % (
+                assert tok[0] in (tokenize.NAME, tokenize.NUMBER), "Invalid syntax in expression at %d: %r" % (
                     tok[2][1], tok[-1],
                 )
                 var.append(tok[1])

--- a/stencil.py
+++ b/stencil.py
@@ -101,27 +101,21 @@ class Template(object):
 
 
 class Expression(object):
-    def __str__(self):
-        return '%r %r' % (self.value, self.filters)
-
     def __init__(self, expr):
         self.tokens = tokenize.generate_tokens(io.StringIO(expr).readline)
         tok = next(self.tokens)
 
-        # Parse initial value: lit number | lit string | lit float | lookup
         value, tok = self.parse_argument(tok)
         self.value = value
 
         filters = []
         while tok[0] == tokenize.OP and tok[1] == '|':
-            # Parse filters
             tok = next(self.tokens)
             assert tok[0] == tokenize.NAME, "Invalid syntax in expression at %d.  Expected name." % (tok[2][1],)
             filt = tok[1]
             args = []
             tok = next(self.tokens)
             if tok[0] == tokenize.OP and tok[1] == ':':
-                # Arguments
                 value, tok = self.parse_argument(tok)
                 args.append(value)
                 while tok[0] == tokenize.OP and tok[1] == ',':

--- a/stencil.py
+++ b/stencil.py
@@ -145,7 +145,7 @@ class Expression(object):
         elif tok[0] == tokenize.NAME:
             var = [tok[1]]
             tok = next(self.tokens)
-            while tok[0] == tokenize.OP and tok[1] == '>':
+            while tok[0] == tokenize.OP and tok[1] == ':':
                 tok = next(self.tokens)
                 assert tok[0] in (tokenize.NAME, tokenize.NUMBER), "Invalid syntax in expression at %d: %r" % (
                     tok[2][1], tok[-1],

--- a/test.py
+++ b/test.py
@@ -17,6 +17,8 @@ for fn in sorted(glob.glob('tmpl/*.tpl')):
     try:
         t = loader.load(os.path.basename(fn))
     except:
+        import traceback
+        traceback.print_exc()
         print "FAIL"
         continue
 

--- a/test.py
+++ b/test.py
@@ -14,7 +14,11 @@ for fn in sorted(glob.glob('tmpl/*.tpl')):
     print fn,
     base, ext = os.path.splitext(fn)
 
-    t = loader.load(os.path.basename(fn))
+    try:
+        t = loader.load(os.path.basename(fn))
+    except:
+        print "FAIL"
+        continue
 
     with open(base + '.out', 'r') as fin:
         out = fin.read()

--- a/tmpl/01_simple.tpl
+++ b/tmpl/01_simple.tpl
@@ -1,2 +1,2 @@
 Hello, {{ name }}.
-Everyone, it's {{ name.title }}!
+Everyone, it's {{ name>title }}!

--- a/tmpl/01_simple.tpl
+++ b/tmpl/01_simple.tpl
@@ -1,2 +1,2 @@
 Hello, {{ name }}.
-Everyone, it's {{ name>title }}!
+Everyone, it's {{ name:title }}!

--- a/tmpl/06_include.tpl
+++ b/tmpl/06_include.tpl
@@ -1,1 +1,1 @@
-{% include 01_simple.tpl name=first_name %}
+{% include "01_simple.tpl" name=first_name %}

--- a/tmpl/07_var.out
+++ b/tmpl/07_var.out
@@ -2,3 +2,5 @@
 hat
 value
 two
+literal
+123

--- a/tmpl/07_var.tpl
+++ b/tmpl/07_var.tpl
@@ -1,6 +1,6 @@
 {{ invalid }}
 {{ top }}
-{{ map>key }}
-{{ sequence>2 }}
+{{ map:key }}
+{{ sequence:2 }}
 {{ "literal" }}
 {{ 123 }}

--- a/tmpl/07_var.tpl
+++ b/tmpl/07_var.tpl
@@ -2,3 +2,5 @@
 {{ top }}
 {{ map.key }}
 {{ sequence.2 }}
+{{ "literal" }}
+{{ 123 }}

--- a/tmpl/07_var.tpl
+++ b/tmpl/07_var.tpl
@@ -1,6 +1,6 @@
 {{ invalid }}
 {{ top }}
-{{ map.key }}
-{{ sequence.2 }}
+{{ map>key }}
+{{ sequence>2 }}
 {{ "literal" }}
 {{ 123 }}

--- a/tmpl/10_extends.tpl
+++ b/tmpl/10_extends.tpl
@@ -1,4 +1,4 @@
-{% extends 10_parent.html %}
+{% extends "10_parent.html" %}
 {% block title %}Welcome!{% endblock %}
 content outside blocks are ignored
 {% block footer %}Footer{% endblock %}


### PR DESCRIPTION
Expand Expression class (and its uses) to support parsing literals.

Because of how Python's tokenize works, we have to change from '.' to ':'
